### PR TITLE
fix label to show max read length

### DIFF
--- a/quack.c
+++ b/quack.c
@@ -760,7 +760,7 @@ void draw(sequence_data* data, int position, int adapters_used) {
   
   svg_axis_label(225,  y+5, 0, "Base Pairs");
   svg_axis_number(0,   y, "middle", 0);
-  svg_axis_number(450, y, "middle", 100);
+  svg_axis_number(450, y, "middle", data->max_length);
 
   
   svg_end_tag("g"); // rug plot vertical section


### PR DESCRIPTION
The bottom label is hard-coded to 100 but should show
the max read length found in the fastq file, which is
stored in data->max_length

Unless I mis-interpreted the figure.